### PR TITLE
[chore] add node-proxy kit

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,3 +1,3 @@
 REPO monk-nginx
-LOAD manifest.yaml
+LOAD manifest.yaml node-proxy.yaml
 RESOURCES files/index.html files/entrypoint-certbot.sh files/entrypoint-nginx.sh files/letsencrypt_init.conf files/letsencrypt_running.conf

--- a/node-proxy.yaml
+++ b/node-proxy.yaml
@@ -1,0 +1,86 @@
+namespace: nginx
+
+node-proxy:
+  defines: runnable
+  containers:
+    nginx:
+      image: docker.io/bitnami/nginx
+      image-tag: latest
+  services:
+    nginx:
+      port: <- $listen-port
+      host-port: <- $host-port
+      container: nginx
+      protocol: tcp
+      publish: true
+#  connections:
+#    backend:
+#      runnable: example/backend
+#      service: api
+  variables:
+    host-port:
+      type: int
+      value: 443
+    listen-port:
+      type: int
+      value: 8443
+    backend-host:
+      type: string
+      value: <- connection-hostname("backend")
+    backend-port:
+      value: <- connection-port("backend")
+      type: int
+    resolver-ip:
+      value: <- get-resolver-ip
+      type: string
+    proxy-pass-protocol:
+      type: string
+      value: http
+  files:
+    defines: files
+    nginx-cert:
+      mode: 511
+      container: nginx
+      path: /etc/nginx/conf.d/nginx.crt
+      contents: <- ssl-certificate
+    nginx-key:
+      mode: 511
+      container: nginx
+      path: /etc/nginx/conf.d/nginx.key
+      contents: <- ssl-private-key
+    server-def:
+      mode: 511
+      container: nginx
+      path: /opt/bitnami/nginx/conf/server_blocks/reverse_proxy.conf
+      contents: |
+        server {
+          listen 0.0.0.0:{{ v "listen-port" }} default_server ssl;
+
+          resolver {{ v "resolver-ip" }} valid=30s;
+        
+          proxy_pass_request_headers on;
+          proxy_http_version 1.1;
+          proxy_set_header X-Forwarded-Host $host;
+          proxy_set_header X-Forwarded-Server $host;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header Host $host;
+        
+          # SSL
+          ssl_certificate /etc/nginx/conf.d/nginx.crt;
+          ssl_certificate_key /etc/nginx/conf.d/nginx.key;
+        
+          # Recommendations from https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
+          ssl_protocols TLSv1.1 TLSv1.2;
+          ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
+          ssl_prefer_server_ciphers on;
+          ssl_session_cache shared:SSL:10m;
+
+          {{ if v "backend-host" }}
+          set $backend_upstream http://{{ v "backend-host" }}:{{ v "backend-port" }};
+          location / {
+            proxy_pass $backend_upstream;
+          }
+          {{ end }}
+        }


### PR DESCRIPTION
This pull request introduces a new `node-proxy.yaml` file and updates the `MANIFEST` file to include this new configuration. The changes primarily focus on adding a new node proxy setup for the nginx namespace.

Key changes include:

### Configuration Updates:
* [`MANIFEST`](diffhunk://#diff-bd43a7da36c1cfe19eebcdf7324f4e3aeec37a5c48ce180964e8c68c4abefc2cL2-R2): Updated to load `node-proxy.yaml` in addition to `manifest.yaml`.

### New Configuration File:
* [`node-proxy.yaml`](diffhunk://#diff-79da5f10e0ce011997ae54265bca9d7ebd6002bc08ffb628e4819a80984cc45aR1-R86): Added a new configuration file to define a runnable node proxy for nginx, specifying containers, services, variables, and file definitions.